### PR TITLE
Added workspace id in the Login Api Response

### DIFF
--- a/lib/dailyploy/model/user.ex
+++ b/lib/dailyploy/model/user.ex
@@ -36,6 +36,7 @@ defmodule Dailyploy.Model.User do
     case email_password_auth(email, password) do
       {:ok, user} ->
         Guardian.encode_and_sign(user)
+        |> Tuple.insert_at(2, get_current_workspace(user).id)
 
       _ ->
         {:error, :unauthorized}

--- a/lib/dailyploy_web/controllers/session_controller.ex
+++ b/lib/dailyploy_web/controllers/session_controller.ex
@@ -32,8 +32,8 @@ defmodule DailyployWeb.SessionController do
 
   def sign_in(conn, %{"email" => email, "password" => password}) do
     case UserModel.token_sign_in(email, password) do
-      {:ok, token, _claims} ->
-        conn |> render("access_token.json", access_token: token)
+      {:ok, token, workspace_id, _claims} ->
+        conn |> render("access_token.json", access_token: token, workspace_id: workspace_id)
 
       _ ->
         {:error, :unauthorized}

--- a/lib/dailyploy_web/views/session_view.ex
+++ b/lib/dailyploy_web/views/session_view.ex
@@ -11,8 +11,8 @@ defmodule DailyployWeb.SessionView do
     %{id: user.id, name: user.name, email: user.email}
   end
 
-  def render("access_token.json", %{access_token: access_token}) do
-    %{access_token: access_token}
+  def render("access_token.json", %{access_token: access_token, workspace_id: workspace_id}) do
+    %{access_token: access_token, workspace_id: workspace_id}
   end
 
   def render("signup_error.json", %{user: user}) do


### PR DESCRIPTION
Fixes: Added workspace id in the login api response so that, it gets used to redirect user to a particular workspace instead of normal dashboard